### PR TITLE
change springboot to 2.3.3

### DIFF
--- a/boogle-maps/pom.xml
+++ b/boogle-maps/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.5.RELEASE</version>
+		<version>2.3.3.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.udacity</groupId>

--- a/pricing-service/pom.xml
+++ b/pricing-service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.5.RELEASE</version>
+		<version>2.3.3.RELEASE</version>
 		<relativePath/> <!-- lookup parent from com.udacity.pricing.repository -->
 	</parent>
 	<groupId>com.udacity</groupId>

--- a/vehicles-api/pom.xml
+++ b/vehicles-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.5.RELEASE</version>
+        <version>2.3.3.RELEASE</version>
         <relativePath/> <!-- lookup parent from com.udacity.pricing.repository -->
     </parent>
     <groupId>com.udacity</groupId>
@@ -69,6 +69,13 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/io.projectreactor/reactor-core -->
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>3.3.9.RELEASE</version>
         </dependency>
 
         <dependency>

--- a/vehicles-api/src/main/java/com/udacity/vehicles/api/CarController.java
+++ b/vehicles-api/src/main/java/com/udacity/vehicles/api/CarController.java
@@ -1,8 +1,7 @@
 package com.udacity.vehicles.api;
 
-
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 import com.udacity.vehicles.domain.car.Car;
 import com.udacity.vehicles.service.CarService;
@@ -12,8 +11,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.validation.Valid;
 
-import org.springframework.hateoas.Resource;
-import org.springframework.hateoas.Resources;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.CollectionModel;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -44,10 +43,10 @@ class CarController {
      * @return list of vehicles
      */
     @GetMapping
-    Resources<Resource<Car>> list() {
-        List<Resource<Car>> resources = carService.list().stream().map(assembler::toResource)
+    CollectionModel<EntityModel<Car>> list() {
+        List<EntityModel<Car>> resources = carService.list().stream().map(assembler::toModel)
                 .collect(Collectors.toList());
-        return new Resources<>(resources,
+        return CollectionModel.of(resources,
                 linkTo(methodOn(CarController.class).list()).withSelfRel());
     }
 
@@ -57,13 +56,13 @@ class CarController {
      * @return all information for the requested vehicle
      */
     @GetMapping("/{id}")
-    Resource<Car> get(@PathVariable Long id) {
+    EntityModel<Car> get(@PathVariable Long id) {
         /**
          * TODO: Use the `findById` method from the Car Service to get car information.
          * TODO: Use the `assembler` on that car and return the resulting output.
          *   Update the first line as part of the above implementing.
          */
-        return assembler.toResource(new Car());
+        return assembler.toModel(new Car());
     }
 
     /**
@@ -79,8 +78,10 @@ class CarController {
          * TODO: Use the `assembler` on that saved car and return as part of the response.
          *   Update the first line as part of the above implementing.
          */
-        Resource<Car> resource = assembler.toResource(new Car());
-        return ResponseEntity.created(new URI(resource.getId().expand().getHref())).body(resource);
+        EntityModel<Car> resource = assembler.toModel(new Car());
+        // return ResponseEntity.created(new URI(resource.getId().expand().getHref())).body(resource);
+        return ResponseEntity.created(new URI(resource.getContent().getId().toString())).body(resource);
+
     }
 
     /**
@@ -97,7 +98,7 @@ class CarController {
          * TODO: Use the `assembler` on that updated car and return as part of the response.
          *   Update the first line as part of the above implementing.
          */
-        Resource<Car> resource = assembler.toResource(new Car());
+        EntityModel<Car> resource = assembler.toModel(new Car());
         return ResponseEntity.ok(resource);
     }
 

--- a/vehicles-api/src/main/java/com/udacity/vehicles/api/CarResourceAssembler.java
+++ b/vehicles-api/src/main/java/com/udacity/vehicles/api/CarResourceAssembler.java
@@ -1,21 +1,21 @@
 package com.udacity.vehicles.api;
 
 import com.udacity.vehicles.domain.car.Car;
-import org.springframework.hateoas.Resource;
-import org.springframework.hateoas.ResourceAssembler;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelAssembler;
 import org.springframework.stereotype.Component;
 
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.*;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
 
 /**
  * Maps the CarController to the Car class using HATEOAS
  */
 @Component
-public class CarResourceAssembler implements ResourceAssembler<Car, Resource<Car>> {
+public class CarResourceAssembler implements RepresentationModelAssembler<Car, EntityModel<Car>> {
 
     @Override
-    public Resource<Car> toResource(Car car) {
-        return new Resource<>(car,
+    public EntityModel<Car> toModel(Car car) {
+        return EntityModel.of(car,
                 linkTo(methodOn(CarController.class).get(car.getId())).withSelfRel(),
                 linkTo(methodOn(CarController.class).list()).withRel("cars"));
 

--- a/vehicles-api/src/main/java/com/udacity/vehicles/api/ErrorController.java
+++ b/vehicles-api/src/main/java/com/udacity/vehicles/api/ErrorController.java
@@ -2,7 +2,7 @@ package com.udacity.vehicles.api;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import org.springframework.hateoas.VndErrors;
+//import org.springframework.hateoas.VndErrors;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/vehicles-api/src/main/java/com/udacity/vehicles/client/maps/MapsClient.java
+++ b/vehicles-api/src/main/java/com/udacity/vehicles/client/maps/MapsClient.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 /**
  * Implements a class to interface with the Maps Client for location data.
@@ -33,7 +34,7 @@ public class MapsClient {
      */
     public Location getAddress(Location location) {
         try {
-            Address address = client
+            Mono<Address> address = client
                     .get()
                     .uri(uriBuilder -> uriBuilder
                             .path("/maps/")
@@ -41,7 +42,7 @@ public class MapsClient {
                             .queryParam("lon", location.getLon())
                             .build()
                     )
-                    .retrieve().bodyToMono(Address.class).block();
+                    .retrieve().bodyToMono(Address.class);
 
             mapper.map(Objects.requireNonNull(address), location);
 


### PR DESCRIPTION
The starter project spring boot version was 2.1.5 which is not available. And I have changed to 2.3.3 which results in hateoas deprecated errors which is resolved by incorporating the new methods i.e.

`ResourceSupport` is now `RepresentationModel`

`Resource` is now `EntityModel`

`Resources` is now `CollectionModel`

`ResourceAssembler` has been renamed to `RepresentationModelAssembler` and its methods `toResource(…)` and `toResources(…) `have been renamed to `toModel(…)` and `toCollectionModel(…)` respectively. 

The change log for hateoas can be found at [hateoas reference](https://docs.spring.io/spring-hateoas/docs/current/reference/html/)